### PR TITLE
第4章：意図を語るテスト

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -1,6 +1,6 @@
 - [ ] $5 + 10 CHF = $10（レートが2:1の場合）
 - [x] $5 * 2 = $10
-- [ ] amount を private にする
+- [x] amount を private にする
 - [x] Dollar の副作用をどうする？
 - [ ] Money の丸め処理をどうする？
 - [x] equals()

--- a/app/money/src/Dollar.php
+++ b/app/money/src/Dollar.php
@@ -7,7 +7,7 @@ namespace Money;
 class Dollar
 {
     public function __construct(
-        public int $amount
+        private readonly int $amount
     )
     {
     }

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -12,10 +12,9 @@ final class MoneyTest extends TestCase
     public function testMultiplication()
     {
         $five = new Dollar(5);
-        $product = $five->times(2);
-        $this->assertEquals(10, $product->amount);
-        $product = $five->times(3);
-        $this->assertEquals(15, $product->amount);
+
+        $this->assertEquals(new Dollar(10), $five->times(2));
+        $this->assertEquals(new Dollar(15), $five->times(3));
     }
 
     public function testEquality()

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -13,8 +13,8 @@ final class MoneyTest extends TestCase
     {
         $five = new Dollar(5);
 
-        $this->assertEquals(new Dollar(10), $five->times(2));
-        $this->assertEquals(new Dollar(15), $five->times(3));
+        $this->assertObjectEquals(new Dollar(10), $five->times(2));
+        $this->assertObjectEquals(new Dollar(15), $five->times(3));
     }
 
     public function testEquality()


### PR DESCRIPTION
第1部 多国通貨：第4章 意図を語るテスト 写経完了

### やったこと
1. MoneyTest の`assertEquals`でプロパティで比較していた箇所をオブジェクトで比較するようにした
2. Dollar のプロパティを参照しなくなったので アクセス権を public→private へ変更した

### 学びなど
- オブジェクトの比較でJavaでは`assertEquals`使ってたけど、PHPでは`assertObjectEquals`を使わないと厳密には行えないようだ
参考：https://github.com/sebastianbergmann/phpunit-documentation-japanese/blob/main/src/assertions.rst



### 気になった・困ったところ
- オブジェクトの比較のメソッドについて気になって調べてたら時間かかった
- `assertEquals`でもテストは通っていたけど、、まぁしょうがないか
- PHPで写経しているから、テストは通るけどこれがベストか？については気になるところ