### PR TITLE
第5章：原則をあえて破るとき

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -7,3 +7,7 @@
 - [ ] hashCode()
 - [ ] null との等価性比較
 - [ ] 他のオブジェクトとの等価性比較
+- [x] 5 CHF * 2 = 10 CHF
+- [ ] Dollar と Franc の重複
+- [x] equals の一般化
+- [x] times の一般化

--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -9,5 +9,5 @@
 - [ ] 他のオブジェクトとの等価性比較
 - [x] 5 CHF * 2 = 10 CHF
 - [ ] Dollar と Franc の重複
-- [x] equals の一般化
-- [x] times の一般化
+- [ ] equals の一般化
+- [ ] times の一般化

--- a/app/money/src/Franc.php
+++ b/app/money/src/Franc.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Money;
+
+class Franc
+{
+    public function __construct(
+        private readonly int $amount
+    )
+    {
+    }
+
+    public function times(int $multiplier): self
+    {
+        return new self($this->amount * $multiplier);
+    }
+
+    public function equals(self $object): bool
+    {
+        return $this->amount === $object->amount;
+    }
+}

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Money;
 
 use Money\Dollar;
+use Money\Franc;
 use PHPUnit\Framework\TestCase;
 
 final class MoneyTest extends TestCase

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -22,4 +22,12 @@ final class MoneyTest extends TestCase
         $this->assertTrue((new Dollar(5))->equals(new Dollar(5)));
         $this->assertFalse((new Dollar(5))->equals(new Dollar(6)));
     }
+
+    public function testFrancMultiplication()
+    {
+        $five = new Franc(5);
+
+        $this->assertObjectEquals(new Franc(10), $five->times(2));
+        $this->assertObjectEquals(new Franc(15), $five->times(3));
+    }
 }


### PR DESCRIPTION
第1部 多国通貨：第5章 原則をあえて破るとき 写経完

### やったこと
- ドル・フランの計算を行う前段階として、フランのテストを実装した
- ただしそれだとテスト結果がレッドバーとなるため、
ドルのオブジェクトをそのままコピーしてフランオブジェクトを作成した
- コードがほぼ重複しているがテスト結果はグリーンバーとすることができた

### 学びなど
- 最初に写経をやった時はひたすらに Java で書いてあるコードを PHP で書いてコミットをしていたが、
特に振り返りとかやったないからあんまり覚えてなかったから、こうして振り返るのは良い気がする

>ドルのオブジェクトをそのままコピーしてフランオブジェクトを作成

こういう対応は同じようなクラスを作る場合よくやるから、
これからどう重複をなくしていくかが気になるところ

### 気になったところ・困ったところ
なし