### PR TITLE
第7章：疑念をテストに翻訳する

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -11,4 +11,5 @@
 - [ ] Dollar と Franc の重複
 - [x] equals の一般化
 - [ ] times の一般化
-- [ ] Franc と Dollar を比較する
+- [x] Franc と Dollar を比較する
+- [ ] 通貨の概念

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -10,6 +10,7 @@ class Money
 
     public function equals(Money $object): bool
     {
-        return $this->amount === $object->amount;
+        return $this->amount === $object->amount
+            && get_class($this) === get_class($object);
     }
 }

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -24,6 +24,7 @@ final class MoneyTest extends TestCase
         $this->assertFalse((new Dollar(5))->equals(new Dollar(6)));
         $this->assertTrue((new Franc(5))->equals(new Franc(5)));
         $this->assertFalse((new Franc(5))->equals(new Franc(6)));
+        $this->assertFalse((new Franc(5))->equals(new Dollar(5)));
     }
 
     public function testFrancMultiplication()


### PR DESCRIPTION
第1部 多国通過：第7章：疑念をテストに翻訳する 写経完

### やったこと
- 前章で気になっていた ドルとフランを比較したらどうなるか？という疑念を解消するためにテストを実施
- レッドバーとなるため、グリーンバーとするために Money クラスの`equals`メソッドを修正した。

### 学びなど
- オブジェクトがどのクラスか？をPHP調べるには`get_class`関数を使用する
- 業務で使ったことないけどどういう時に使うのかしら
- https://www.php.net/manual/ja/function.get-class.php

- 気になったことをどんどん試して納得させるのはエンジニアに必要だよね
### 気になったところ・困ったところ
なし