### PR TITLE
第13章 実装を導くテスト

### DIFF
--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -1,4 +1,6 @@
 - [ ] $5 + 10 CHF = $10（レートが2:1の場合）
+- [ ] $5 + $5 = $10
+- [x] $5 + $5 が Money を返す
 - [x] $5 * 2 = $10
 - [x] amount を private にする
 - [x] Dollar の副作用をどうする？
@@ -14,4 +16,3 @@
 - [x] Franc と Dollar を比較する
 - [x] 通貨の概念
 - [x] testFrancMultiplication を削除する？
-- [ ] $5 + $5 = $10

--- a/app/money/TODO.md
+++ b/app/money/TODO.md
@@ -1,6 +1,9 @@
 - [ ] $5 + 10 CHF = $10（レートが2:1の場合）
 - [ ] $5 + $5 = $10
-- [x] $5 + $5 が Money を返す
+- [ ] $5 + $5 が Money を返す
+- [x] Bank.reduce(Money)
+- [ ] Money を変換して換算を行う
+- [ ] Reduce(Bank, String)
 - [x] $5 * 2 = $10
 - [x] amount を private にする
 - [x] Dollar の副作用をどうする？

--- a/app/money/src/Bank.php
+++ b/app/money/src/Bank.php
@@ -6,8 +6,11 @@ namespace Money;
 
 class Bank
 {
-    public function reduce(Expression $source, string $to)
+    public function reduce(Expression $source, string $to): Money
     {
-        return Money::dollar(10);
+        $cast = fn($source): Sum => $source;
+        $sum = $cast($source);
+
+        return $sum->reduce($to);
     }
 }

--- a/app/money/src/Bank.php
+++ b/app/money/src/Bank.php
@@ -8,6 +8,10 @@ class Bank
 {
     public function reduce(Expression $source, string $to): Money
     {
+        if ($source instanceof Money) {
+            return $source;
+        }
+
         $cast = fn($source): Sum => $source;
         $sum = $cast($source);
 

--- a/app/money/src/Bank.php
+++ b/app/money/src/Bank.php
@@ -8,13 +8,6 @@ class Bank
 {
     public function reduce(Expression $source, string $to): Money
     {
-        if ($source instanceof Money) {
-            return $source;
-        }
-
-        $cast = fn($source): Sum => $source;
-        $sum = $cast($source);
-
-        return $sum->reduce($to);
+        return $source->reduce($to);
     }
 }

--- a/app/money/src/Expression.php
+++ b/app/money/src/Expression.php
@@ -6,4 +6,5 @@ namespace Money;
 
 interface Expression
 {
+    public function reduce(string $to): Money;
 }

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -26,9 +26,9 @@ class Money implements Expression
         return $this->currency;
     }
 
-    public function plus(Money $addend): Expression
+    public function plus(Money $addend): Sum
     {
-        return new Money($this->amount + $addend->amount, $this->currency);
+        return new Sum($this, $addend);
     }
 
     public function equals(self $object): bool

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -6,7 +6,7 @@ namespace Money;
 
 class Money implements Expression
 {
-    protected int $amount;
+    public readonly int $amount;
 
     protected string $currency;
 

--- a/app/money/src/Money.php
+++ b/app/money/src/Money.php
@@ -21,6 +21,11 @@ class Money implements Expression
         return new self($this->amount * $multiplier, $this->currency());
     }
 
+    public function reduce(string $to): Money
+    {
+        return $this;
+    }
+
     public function currency(): string
     {
         return $this->currency;

--- a/app/money/src/Sum.php
+++ b/app/money/src/Sum.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Money;
 
-class Sum
+class Sum implements Expression
 {
     public Money $augend;
     public Money $addend;
@@ -13,5 +13,11 @@ class Sum
     {
         $this->augend = $augend;
         $this->addend = $addend;
+    }
+
+    public function reduce(string $to): Money
+    {
+        $amount = $this->augend->amount + $this->addend->amount;
+        return new Money($amount, $to);
     }
 }

--- a/app/money/src/Sum.php
+++ b/app/money/src/Sum.php
@@ -8,4 +8,10 @@ class Sum
 {
     public Money $augend;
     public Money $addend;
+
+    public function __construct(Money $augend, Money $addend)
+    {
+        $this->augend = $augend;
+        $this->addend = $addend;
+    }
 }

--- a/app/money/src/Sum.php
+++ b/app/money/src/Sum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Money;
+
+class Sum
+{
+    public Money $augend;
+    public Money $addend;
+}

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -51,4 +51,12 @@ final class MoneyTest extends TestCase
         $this->assertEquals($five, $sum->augend);
         $this->assertEquals($five, $sum->addend);
     }
+
+    public function testReduceSum()
+    {
+        $sum = new Sum(Money::dollar(3), Money::dollar(4));
+        $bank = new Bank();
+        $result = $bank->reduce($sum, 'USD');
+        $this->assertEquals(Money::dollar(7), $result);
+    }
 }

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -6,6 +6,7 @@ namespace Tests\Money;
 
 use Money\Bank;
 use Money\Money;
+use Money\Sum;
 use PHPUnit\Framework\TestCase;
 
 final class MoneyTest extends TestCase
@@ -38,5 +39,16 @@ final class MoneyTest extends TestCase
         $bank = new Bank();
         $reduced = $bank->reduce($sum, 'USD');
         $this->assertEquals(Money::dollar(10), $reduced);
+    }
+
+    public function testPlusReturnsSum()
+    {
+        $five = Money::dollar(5);
+        $result = $five->plus($five);
+        $cast = fn($result): Sum => $result;
+        $sum = $cast($result);
+
+        $this->assertEquals($five, $sum->augend);
+        $this->assertEquals($five, $sum->addend);
     }
 }

--- a/app/money/tests/MoneyTest.php
+++ b/app/money/tests/MoneyTest.php
@@ -59,4 +59,11 @@ final class MoneyTest extends TestCase
         $result = $bank->reduce($sum, 'USD');
         $this->assertEquals(Money::dollar(7), $result);
     }
+
+    public function testReduceMoney()
+    {
+        $bank = new Bank();
+        $result = $bank->reduce(Money::dollar(1), 'USD');
+        $this->assertEquals(Money::dollar(1), $result);
+    }
 }


### PR DESCRIPTION
第1部 多国通過：第13章 実装を導くテスト

## やったこと
- ここでもまず実装・・・ではなくまずテストコードを書き、その後に実装を行うを徹底
- Moneyクラスのプロパティのアクセス修飾子を修正
- 新たに`Sum`クラスを作成：２つのMoneyの合計を返すクラス
- reduce メソッドを親クラス（Expressionインターフェース）に引き上げた
<img width="621" alt="image" src="https://github.com/Tomo-kw/book-tdd-php82/assets/68243050/644caf49-2875-4b75-b2a1-aa00a5e34184">

## 学びなど
- 継承元が同じクラスで、同じようなメソッドであれば親クラスに定義することを考える
- 各クラスで書くのは冗長
- まずテストコード
- 細かすぎてなかなか流れを理解するのに時間がかかった
- これを何も見ずにやるのは難易度高そう
- 何度もやっていかないと理解しTDDを実践するのは難しいなぁ

## 気になったところ・困ったところ
- Javaで書かれているけど、PHPで書くにあたり同じ記述だと動作しない
ほんっっとにこれで時間かかった。。。
そこまで時間かける必要なかったかもしれない

### protected の仕様が違う
- Java：同一パッケージまたはサブクラスからは参照可能
- PHP：同じクラスかサブクラス
書き込みできなければいいでしょうとの考えで`public readonly`にした

### 独自クラスの型キャストができない
- Java：`（Sum）result `
なので、以下サイトを参考にアロー関数で実装した
```
    public function testPlusReturnsSum()
    {
        $five = Money::dollar(5);
        $result = $five->plus($five);
        $cast = fn($result): Sum => $result;
        $sum = $cast($result);

        $this->assertEquals($five, $sum->augend);
        $this->assertEquals($five, $sum->addend);
    }
```